### PR TITLE
Fix minor arg parsing issue in cmd line.

### DIFF
--- a/src/materialxjson/__main__.py
+++ b/src/materialxjson/__main__.py
@@ -6,8 +6,9 @@ def main() -> int:
     Main entry point
     '''
     argCount = len(sys.argv)
-    if sys.argv[1] == '-h' or sys.argv[1] == '--help':
+    if argCount < 2 or sys.argv[1] == '-h' or sys.argv[1] == '--help':
         print('Usage: materialxjson <command> [options] where command is j2m or m2j')
+        return 0
 
     # Check if the command is valid
     cmdArgs = sys.argv[1:]


### PR DESCRIPTION
## Change

Fix minor arg parsing issue in cmd line.
- Was assuming arguments so would fail w/o any
- Was not stopping if no args or help arg specified.
